### PR TITLE
pricing retrieval moved behind interface

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func init() {
 
 func main() {
 
-	productInfoProvider, err := ec2.NewAwsInfoer()
+	infoProvider, err := ec2.NewEc2Infoer(ec2.NewPricing(ec2.NewConfig()))
 	if err != nil {
 		log.Fatalf("could not initialize product info provider: %s", err.Error())
 		return
@@ -55,7 +55,7 @@ func main() {
 
 	c := cache.New(24*time.Hour, 24.*time.Hour)
 
-	ec2ProductInfo, err := productinfo.NewProductInfo(*productInfoRenewalInterval, c, productInfoProvider)
+	ec2ProductInfo, err := productinfo.NewProductInfo(*productInfoRenewalInterval, c, infoProvider)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -12,20 +12,27 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// PricingSource list of operations for retrieving pricing information
+// Decouples the pricing logic from the aws api
+type PricingSource interface {
+	GetAttributeValues(input *pricing.GetAttributeValuesInput) (*pricing.GetAttributeValuesOutput, error)
+	GetProducts(input *pricing.GetProductsInput) (*pricing.GetProductsOutput, error)
+}
+
 // Ec2Infoer encapsulates the data and operations needed to access external resources
 type Ec2Infoer struct {
-	pricing *pricing.Pricing
+	pricing PricingSource
 }
 
 // NewEc2Infoer creates a new instance of the infoer
-func NewEc2Infoer(pricing *pricing.Pricing) (*Ec2Infoer, error) {
+func NewEc2Infoer(pricing PricingSource) (*Ec2Infoer, error) {
 
 	return &Ec2Infoer{
 		pricing: pricing,
 	}, nil
 }
 
-func NewPricing(cfg *aws.Config) *pricing.Pricing {
+func NewPricing(cfg *aws.Config) PricingSource {
 
 	s, err := session.NewSession(cfg)
 	if err != nil {

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -1,7 +1,6 @@
 package ec2
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -15,24 +14,37 @@ import (
 
 // Ec2Infoer encapsulates the data and operations needed to access external resources
 type Ec2Infoer struct {
-	session *session.Session
+	pricing *pricing.Pricing
 }
 
-// NewAwsInfoer encapsulates the creation of a infoerapper instance
-func NewAwsInfoer() (*Ec2Infoer, error) {
-	newSession, err := session.NewSession(&aws.Config{})
-
-	if err != nil {
-		return &Ec2Infoer{}, fmt.Errorf("could not create session: %s ", err.Error())
-	}
+// NewEc2Infoer creates a new instance of the infoer
+func NewEc2Infoer(pricing *pricing.Pricing) (*Ec2Infoer, error) {
 
 	return &Ec2Infoer{
-		session: newSession,
+		pricing: pricing,
 	}, nil
 }
 
+func NewPricing(cfg *aws.Config) *pricing.Pricing {
+
+	s, err := session.NewSession(cfg)
+	if err != nil {
+		log.Fatalf("could not create session. error: [%s]", err.Error())
+	}
+
+	pr := pricing.New(s, cfg)
+	return pr
+}
+
+func NewConfig() *aws.Config {
+	// getting the reference can be extracted
+	cfg := &aws.Config{}
+
+	return cfg
+}
+
 func (e *Ec2Infoer) GetAttributeValues(attribute string) (productinfo.AttrValues, error) {
-	apiValues, err := e.pricingService().GetAttributeValues(e.newAttributeValuesInput(attribute))
+	apiValues, err := e.pricing.GetAttributeValues(e.newAttributeValuesInput(attribute))
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +69,7 @@ func (e *Ec2Infoer) GetProducts(regionId string, attrKey string, attrValue produ
 	var vms []productinfo.Ec2Vm
 	log.Debugf("Getting available instance types from AWS API. [region=%s, %s=%s]", regionId, attrKey, attrValue.StrValue)
 
-	products, err := e.pricingService().GetProducts(e.newGetProductsInput(regionId, attrKey, attrValue))
+	products, err := e.pricing.GetProducts(e.newGetProductsInput(regionId, attrKey, attrValue))
 
 	if err != nil {
 		return nil, err
@@ -104,10 +116,6 @@ func (e *Ec2Infoer) GetRegion(id string) *endpoints.Region {
 		}
 	}
 	return nil
-}
-
-func (e *Ec2Infoer) pricingService() *pricing.Pricing {
-	return pricing.New(e.session, &aws.Config{Region: aws.String("us-east-1")})
 }
 
 // newAttributeValuesInput assembles a GetAttributeValuesInput instance for querying the provider

--- a/productinfo/ec2/productinfo_ec2.go
+++ b/productinfo/ec2/productinfo_ec2.go
@@ -45,7 +45,7 @@ func NewPricing(cfg *aws.Config) PricingSource {
 
 func NewConfig() *aws.Config {
 	// getting the reference can be extracted
-	cfg := &aws.Config{}
+	cfg := &aws.Config{Region: aws.String("us-east-1")}
 
 	return cfg
 }

--- a/productinfo/ec2/productinfo_ec2_test.go
+++ b/productinfo/ec2/productinfo_ec2_test.go
@@ -1,0 +1,117 @@
+package ec2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/banzaicloud/cluster-recommender/productinfo"
+	"github.com/stretchr/testify/assert"
+)
+
+type DummyPricingSource struct {
+	TcId int
+}
+
+func (dps *DummyPricingSource) GetAttributeValues(input *pricing.GetAttributeValuesInput) (*pricing.GetAttributeValuesOutput, error) {
+
+	// example json sequence
+	//{
+	//	"Value": "256 GiB"
+	//},
+	//{
+	//"Value": "3,904 GiB"
+	//},
+	//{
+	//"Value": "3.75 GiB"
+	//},
+
+	switch dps.TcId {
+	case 1:
+		return &pricing.GetAttributeValuesOutput{
+			AttributeValues: []*pricing.AttributeValue{
+				{
+					Value: dps.strPointer("256 GiB"),
+				},
+				{
+					Value: dps.strPointer("3,904 GiB"),
+				},
+				{
+					Value: dps.strPointer("3.75 GiB"),
+				},
+			},
+		}, nil
+	case 2:
+		return &pricing.GetAttributeValuesOutput{
+			AttributeValues: []*pricing.AttributeValue{
+				{
+					Value: dps.strPointer("invalid float 256 GiB"),
+				},
+				{
+					Value: dps.strPointer("3,904 GiB"),
+				},
+				{
+					Value: dps.strPointer("3.75 GiB"),
+				},
+			},
+		}, nil
+	case 3:
+		return nil, fmt.Errorf("failed to retrieve values")
+	}
+
+	return nil, nil
+}
+func (dps *DummyPricingSource) GetProducts(input *pricing.GetProductsInput) (*pricing.GetProductsOutput, error) {
+
+	return nil, nil
+}
+
+// strPointer gets the pointer to the passed string
+func (dps *DummyPricingSource) strPointer(str string) *string {
+	return &str
+}
+
+func TestEc2Infoer_GetAttributeValues(t *testing.T) {
+	tests := []struct {
+		name          string
+		pricingServie PricingSource
+		attrName      string
+		check         func(values productinfo.AttrValues, err error)
+	}{
+		{
+			name:          "successfully retrieve attributes",
+			pricingServie: &DummyPricingSource{TcId: 1},
+			check: func(values productinfo.AttrValues, err error) {
+				assert.Equal(t, 3, len(values), "invalid number of values returned")
+				assert.Nil(t, err, "should not get error")
+			},
+		},
+		{
+			name:          "error - invalid values zeroed out",
+			pricingServie: &DummyPricingSource{TcId: 2},
+			check: func(values productinfo.AttrValues, err error) {
+				assert.Equal(t, values[0].StrValue, "invalid float 256 GiB", "the invalid value is not the first element")
+				assert.Equal(t, values[0].Value, float64(0), "the invalid value is not zeroed out")
+				assert.Equal(t, 3, len(values))
+			},
+		},
+		{
+			name:          "error - error when retrieving values",
+			pricingServie: &DummyPricingSource{TcId: 3},
+			check: func(values productinfo.AttrValues, err error) {
+				assert.Equal(t, "failed to retrieve values", err.Error())
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			productInfoer, err := NewEc2Infoer(test.pricingServie)
+			if err != nil {
+				t.Fatalf("failed to create productinfoer; [%s]", err.Error())
+			}
+
+			test.check(productInfoer.GetAttributeValues(test.attrName))
+
+		})
+	}
+}


### PR DESCRIPTION
Further (minor) refactor of the product info
- the pricing(service) is used directly in the info provider struct (not the session instance)
- In order to be able to test the transformation logic between the ec2 types and app specific structs a new interface has been introduced. (it only "defines" a few operation that are implemented by the pricing.Price struct - thus a dummy can be injected with controlled behavior)
- added unit tests for the attribute retrieval (this is to be followed while testing the other operations)